### PR TITLE
feat: add file creation command

### DIFF
--- a/py_ecm/cli.py
+++ b/py_ecm/cli.py
@@ -1,18 +1,85 @@
 '''CLI entry point for Py-ECM'''
 
+from pathlib import Path
+from typing import Optional
 import typer
 
 app = typer.Typer(name="py-ecm", help="Enterprise Content Manager - CLI for content lifecycle operations", add_completion=False,)
 
 @app.command()
 def version():
-    '''Display Py-ECM version.'''
+    """Display Py-ECM version."""
     from py_ecm import __version__
-    typer.echo(f"Py-ECM v{__version__}")
+    typer.echo(f'Py-ECM v{__version__}')
 
+@app.command()
+def create(
+    filename: str = typer.Argument(..., help='Name of file to create'),
+    directory: Optional[str] = typer.Option(None, '--dir', '-d', help='Directory path (default: current directory)'),
+    content: Optional[str] = typer.Option('', '--content', '-c', help='Initial file content'),) -> None:
+    """Create a new file with optional content."""
+    
+    # Determine full path
+    if directory:
+        base_path = Path(directory)
+        if not base_path.exists():
+            typer.secho(
+                f'ERROR\nDirectory does not exist: {directory}',  
+                err=True
+            )
+            raise typer.Exit(1)
+        file_path = base_path / filename
+    else:
+        file_path = Path.cwd() / filename
+
+    # Check if path/target is a directory
+    if file_path.exists() and file_path.is_dir():
+        typer.secho(
+            f"ERROR\n'{filename}' is a directory", 
+            err=True
+        )
+        raise typer.Exit(1)
+    
+    # Create file with error handling
+    try:
+        with open(file_path, 'x') as f:
+            if content:
+                f.write(content)
+        
+        typer.secho(
+            f'File created successfully: {file_path}'
+        )
+        
+    except FileExistsError:
+        typer.secho(
+            f'ERROR\nFile already exists: {file_path}',  
+            err=True
+        )
+        raise typer.Exit(1)
+        
+    except PermissionError:
+        typer.secho(
+            f'ERROR\nPermission denied: {file_path}',  
+            err=True
+        )
+        raise typer.Exit(1)
+        
+    except IsADirectoryError:
+        typer.secho(
+            f"ERROR\n'{filename}' is a directory name", 
+            err=True
+        )
+        raise typer.Exit(1)
+        
+    except OSError as e:
+        typer.secho(
+            f'ERROR\nSystem error: {e}', 
+            err=True
+        )
+        raise typer.Exit(1)
 
 def main():
-    '''Main entry point.'''
+    """Main entry point."""
     app()
 
 

--- a/py_ecm/cli.py
+++ b/py_ecm/cli.py
@@ -24,7 +24,8 @@ def create(
         base_path = Path(directory)
         if not base_path.exists():
             typer.secho(
-                f'ERROR\nDirectory does not exist: {directory}',  
+                f'ERROR\nDirectory does not exist: {directory}', 
+                fg=typer.colors.RED, 
                 err=True
             )
             raise typer.Exit(1)
@@ -35,7 +36,8 @@ def create(
     # Check if path/target is a directory
     if file_path.exists() and file_path.is_dir():
         typer.secho(
-            f"ERROR\n'{filename}' is a directory", 
+            f"ERROR\n'{filename}' is a directory",
+            fg=typer.colors.RED, 
             err=True
         )
         raise typer.Exit(1)
@@ -47,12 +49,14 @@ def create(
                 f.write(content)
         
         typer.secho(
-            f'File created successfully: {file_path}'
+            f'File created successfully: {file_path}', 
+            fg=typer.colors.GREEN
         )
         
     except FileExistsError:
         typer.secho(
-            f'ERROR\nFile already exists: {file_path}',  
+            f'ERROR\nFile already exists: {file_path}',
+            fg=typer.colors.RED,  
             err=True
         )
         raise typer.Exit(1)
@@ -60,6 +64,7 @@ def create(
     except PermissionError:
         typer.secho(
             f'ERROR\nPermission denied: {file_path}',  
+            fg=typer.colors.RED,
             err=True
         )
         raise typer.Exit(1)
@@ -67,6 +72,7 @@ def create(
     except IsADirectoryError:
         typer.secho(
             f"ERROR\n'{filename}' is a directory name", 
+            fg=typer.colors.RED,
             err=True
         )
         raise typer.Exit(1)
@@ -74,6 +80,7 @@ def create(
     except OSError as e:
         typer.secho(
             f'ERROR\nSystem error: {e}', 
+            fg=typer.colors.RED,
             err=True
         )
         raise typer.Exit(1)


### PR DESCRIPTION
## Summary
Implements file creation functionality with comprehensive error handling

## Changes
- ✅ Add `create` command with Typer CLI
- ✅ Support optional `--dir` and `--content` flags
- ✅ Use pathlib for cross-platform compatibility
- ✅ Comprehensive error handling (FileExists, Permission, NotFound)
- ✅ Colored output for better UX

## Testing
- [x] Create file in current directory
- [x] Create file in specific directory
- [x] Create file with content
- [x] Error handling for all edge cases
- [x] Cross-platform path handling

## Usage
```bash
py-ecm create report.txt
py-ecm create notes.txt --dir ~/Documents
py-ecm create todo.txt --content "Buy milk"
```

## Next Steps
Add `delete` and `list` commands